### PR TITLE
Turn activated button and beacon green

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -18,12 +18,12 @@
       <svg viewBox="0 0 160 120" class="siren__svg">
         <defs>
           <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stop-color="#6f1c1c"/>
-            <stop offset="100%" stop-color="#2a0a0a"/>
+            <stop offset="0%" stop-color="#1c6f45"/>
+            <stop offset="100%" stop-color="#0a2a19"/>
           </linearGradient>
           <radialGradient id="glow" cx="50%" cy="50%" r="50%">
-            <stop offset="0%" stop-color="rgba(255,40,40,.9)"/>
-            <stop offset="100%" stop-color="rgba(255,40,40,0)"/>
+            <stop offset="0%" stop-color="rgba(118,255,178,.9)"/>
+            <stop offset="100%" stop-color="rgba(118,255,178,0)"/>
           </radialGradient>
           <mask id="beamMask">
             <rect width="160" height="120" fill="black"/>

--- a/site/styles.css
+++ b/site/styles.css
@@ -11,7 +11,7 @@
   --muted:#9aa5c4;
   --radius:18px;
   --shadow:0 10px 30px #0008, 0 1px 0 #fff1 inset;
-  --glow:0 0 24px 8px rgba(255,59,59,.35);
+  --glow:0 0 24px 8px rgba(118,255,178,.35);
   --scan:linear-gradient(#0000 48%, #ffffff08 50%, #0000 52%);
 }
 
@@ -48,7 +48,7 @@ body::before, body::after{
 }
 
 .siren{display:grid; place-items:center}
-.siren__svg{width:min(82vw,360px); height:auto; filter:drop-shadow(0 6px 20px #ff3b3b22)}
+.siren__svg{width:min(82vw,360px); height:auto; filter:drop-shadow(0 6px 20px #76ffb222)}
 .siren__dome{transition:filter .3s ease}
 .siren__beam{opacity:.0; transform-origin:80px 70px}
 
@@ -92,7 +92,14 @@ html[data-state="active"] .siren__beam{
   animation:spin 3.8s linear infinite;
 }
 html[data-state="active"] .siren__dome{
-  filter:drop-shadow(0 0 24px rgba(255,59,59,.55)) drop-shadow(0 0 60px rgba(255,59,59,.25));
+  filter:drop-shadow(0 0 24px rgba(118,255,178,.55)) drop-shadow(0 0 60px rgba(118,255,178,.25));
+}
+
+html[data-state="active"] .btn{
+  background:linear-gradient(180deg, #2ed573, #1e9e52);
+  border-color:#1e804b;
+  color:#042;
+  opacity:1;
 }
 @keyframes spin{to{transform:rotate(360deg)}}
 


### PR DESCRIPTION
## Summary
- Update siren SVG gradients and glow to use green tones
- Style activated button with green gradient and full opacity

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0517c60ac8320b8b31970aae8aa0b