### PR TITLE
feat: play scan sound on activation

### DIFF
--- a/__tests__/beacon.test.js
+++ b/__tests__/beacon.test.js
@@ -29,6 +29,39 @@ describe('beacon activation', () => {
     jest.useRealTimers();
   });
 
+  test('plays scan sound on activation', () => {
+    const window = setupDom();
+    const start = jest.fn();
+    const stop = jest.fn();
+    const connect = jest.fn();
+    const oscMock = {
+      type: '',
+      connect,
+      start,
+      stop,
+      frequency: {
+        setValueAtTime: jest.fn(),
+        linearRampToValueAtTime: jest.fn(),
+      },
+    };
+    const createOscillator = jest.fn().mockReturnValue(oscMock);
+    const AudioCtxMock = jest.fn().mockImplementation(() => ({
+      createOscillator,
+      destination: {},
+      currentTime: 0,
+    }));
+    window.AudioContext = AudioCtxMock;
+
+    const btn = window.document.getElementById('beaconBtn');
+    btn.dispatchEvent(new window.Event('click', { bubbles: true }));
+
+    expect(AudioCtxMock).toHaveBeenCalled();
+    expect(createOscillator).toHaveBeenCalled();
+    expect(connect).toHaveBeenCalled();
+    expect(start).toHaveBeenCalled();
+    expect(stop).toHaveBeenCalled();
+  });
+
   test('sub text cycles through messages', () => {
     jest.useFakeTimers();
     const window = setupDom();

--- a/site/app.js
+++ b/site/app.js
@@ -22,6 +22,24 @@ document.addEventListener('DOMContentLoaded', () => {
     sub.style.clipPath = '';
   }
 
+  function playScanSound() {
+    try {
+      const AudioCtx = window.AudioContext || window.webkitAudioContext;
+      if (!AudioCtx) return;
+      const ctx = new AudioCtx();
+      const oscillator = ctx.createOscillator();
+      oscillator.type = 'sine';
+      oscillator.connect(ctx.destination);
+      const now = ctx.currentTime;
+      oscillator.frequency.setValueAtTime(800, now);
+      oscillator.frequency.linearRampToValueAtTime(400, now + 0.5);
+      oscillator.start();
+      oscillator.stop(now + 0.5);
+    } catch (e) {
+      // audio not supported or user gesture required
+    }
+  }
+
   function activate() {
     if (document.documentElement.dataset.state === 'active') return;
     document.documentElement.setAttribute('data-state', 'active');
@@ -30,6 +48,7 @@ document.addEventListener('DOMContentLoaded', () => {
     btn.disabled = true;
     headline.textContent = HEADLINE_TEXT;
     sub.textContent = SUB_TEXTS[subIndex];
+    playScanSound();
     setInterval(cycleSubText, 5000);
   }
 


### PR DESCRIPTION
## Summary
- add gentle scan sound using Web Audio API when beacon activates
- test that activation invokes audio generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0543160808320acd8991880fed050